### PR TITLE
Add missing license files

### DIFF
--- a/filenamegen/LICENSE.md
+++ b/filenamegen/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/pathsearch/LICENSE.md
+++ b/pathsearch/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/shell_compiler/LICENSE.md
+++ b/shell_compiler/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/shell_lexer/LICENSE.md
+++ b/shell_lexer/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/shell_parser/LICENSE.md
+++ b/shell_parser/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/shell_vm/LICENSE.md
+++ b/shell_vm/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md


### PR DESCRIPTION
MIT requires a copy of the license text, so ensure it's included in all crates.